### PR TITLE
Nullable Collection Mints ATA

### DIFF
--- a/consumer/src/events.rs
+++ b/consumer/src/events.rs
@@ -225,7 +225,7 @@ impl Processor {
             collection_id,
             mint: tx.addresses.mint.to_string(),
             owner: tx.addresses.owner.to_string(),
-            associated_token_account: tx.addresses.associated_token_account.to_string(),
+            associated_token_account: Some(tx.addresses.associated_token_account.to_string()),
             ..Default::default()
         };
 
@@ -266,7 +266,7 @@ impl Processor {
         collection_mint.mint = Set(tx.addresses.mint.to_string());
         collection_mint.owner = Set(tx.addresses.owner.to_string());
         collection_mint.associated_token_account =
-            Set(tx.addresses.associated_token_account.to_string());
+            Set(Some(tx.addresses.associated_token_account.to_string()));
 
         CollectionMint::update(&self.db, collection_mint).await?;
 

--- a/entity/src/collection_mints.rs
+++ b/entity/src/collection_mints.rs
@@ -13,8 +13,8 @@ pub struct Model {
     pub mint: String,
     #[sea_orm(column_type = "Text")]
     pub owner: String,
-    #[sea_orm(column_type = "Text")]
-    pub associated_token_account: String,
+    #[sea_orm(column_type = "Text", nullable)]
+    pub associated_token_account: Option<String>,
     pub created_at: DateTime,
 }
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -2,6 +2,7 @@ pub use sea_orm_migration::prelude::*;
 
 mod m20230529_134752_create_collections_table;
 mod m20230530_131917_create_collection_mints_table;
+mod m20230614_132203_make_associated_token_account_nullable_on_collection_mints;
 
 pub struct Migrator;
 
@@ -11,6 +12,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20230529_134752_create_collections_table::Migration),
             Box::new(m20230530_131917_create_collection_mints_table::Migration),
+            Box::new(m20230614_132203_make_associated_token_account_nullable_on_collection_mints::Migration),
         ]
     }
 }

--- a/migration/src/m20230614_132203_make_associated_token_account_nullable_on_collection_mints.rs
+++ b/migration/src/m20230614_132203_make_associated_token_account_nullable_on_collection_mints.rs
@@ -1,0 +1,33 @@
+use sea_orm_migration::prelude::*;
+
+use crate::m20230530_131917_create_collection_mints_table::CollectionMints;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .modify_column(ColumnDef::new(CollectionMints::AssociatedTokenAccount).null())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .modify_column(
+                        ColumnDef::new(CollectionMints::AssociatedTokenAccount).not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+}


### PR DESCRIPTION
## Background
hub-nfts doesn't currently track the ata so migrating over collection mints leaving ata nullable then backfill it in this service.

## Changes
- Make ata on collection mints nullable