### PR TITLE
Backfill collection mint ATA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,10 @@ name = "migration"
 version = "0.1.0"
 dependencies = [
  "async-std",
+ "holaplex-hub-nfts-solana-entity",
  "sea-orm-migration",
+ "solana-sdk",
+ "spl-associated-token-account",
 ]
 
 [[package]]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/lib.rs"
 
 [dependencies]
 async-std = { version = "^1", features = ["attributes", "tokio1"] }
+holaplex-hub-nfts-solana-entity = { path = "./../entity" }
+spl-associated-token-account = "1.1.2"
+solana-sdk = "1.14.8"
 
 [dependencies.sea-orm-migration]
 version = "^0.10.0"

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -3,6 +3,7 @@ pub use sea_orm_migration::prelude::*;
 mod m20230529_134752_create_collections_table;
 mod m20230530_131917_create_collection_mints_table;
 mod m20230614_132203_make_associated_token_account_nullable_on_collection_mints;
+mod m20230616_091724_backfill_associated_token_account_on_collection_mints;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230529_134752_create_collections_table::Migration),
             Box::new(m20230530_131917_create_collection_mints_table::Migration),
             Box::new(m20230614_132203_make_associated_token_account_nullable_on_collection_mints::Migration),
+            Box::new(m20230616_091724_backfill_associated_token_account_on_collection_mints::Migration),
         ]
     }
 }

--- a/migration/src/m20230616_091724_backfill_associated_token_account_on_collection_mints.rs
+++ b/migration/src/m20230616_091724_backfill_associated_token_account_on_collection_mints.rs
@@ -1,0 +1,80 @@
+use std::str::FromStr;
+
+use holaplex_hub_nfts_solana_entity::collection_mints::{ActiveModel, Entity};
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{ActiveModelTrait, EntityTrait, Set},
+    DbErr,
+};
+use solana_sdk::pubkey::Pubkey;
+use spl_associated_token_account::get_associated_token_address;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .add_column_if_not_exists(
+                        ColumnDef::new(CollectionMints::AssociatedTokenAccount)
+                            .text()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        let mints = Entity::find().all(manager.get_connection()).await?;
+
+        for mint in mints {
+            let wallet_address = Pubkey::from_str(&mint.owner)
+                .map_err(|err| DbErr::Custom(format!("Failed to parse Pubkey: {}", err)))?;
+            let mint_address = Pubkey::from_str(&mint.mint)
+                .map_err(|err| DbErr::Custom(format!("Failed to parse Pubkey: {}", err)))?;
+            let associated_token_account =
+                get_associated_token_address(&wallet_address, &mint_address);
+
+            let mut mint: ActiveModel = mint.into();
+            mint.associated_token_account = Set(Some(associated_token_account.to_string()));
+
+            mint.update(db).await?;
+        }
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .modify_column(
+                        ColumnDef::new(CollectionMints::AssociatedTokenAccount)
+                            .text()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(CollectionMints::Table)
+                    .drop_column(CollectionMints::AssociatedTokenAccount)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+enum CollectionMints {
+    Table,
+    AssociatedTokenAccount,
+}


### PR DESCRIPTION
### Changes
- collection mints are being copied over to hub-nfts-solana from hub-nfts without the associated token account. Backfill them once they are in its db to allow for ownership tracking.